### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           go-version-file: go.mod
           check-latest: true
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         if: ${{ !env.ACT }}
         with:
           path: ~/go/pkg/mod

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ jobs:
     name: release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           repository: nektos/act
           path: act

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
       - run: rm -rf act/.git
       - run: mv act/* .
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           check-latest: true


### PR DESCRIPTION
These are independent of everything else. (w/ and w/o these changes, [v0.2.71](https://github.com/nektos/gh-act/tree/refs/tags/v0.2.71) doesn't build)